### PR TITLE
feat: capture from start of tmux pane history

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ require('cmp').setup({
 
         -- Keyword patch mattern
         keyword_pattern = [[\w\+]],
+
+        -- Capture full pane history
+        -- `false`: show completion suggestion from text in the visible pane (default)
+        -- `true`: show completion suggestion from text starting from the beginning of the pane history.
+        --         This works by passing `-S -` flag to `tmux capture-pane` command. See `man tmux` for details.
+        capture_history = false,
       }
     }
   }

--- a/doc/cmp-tmux.txt
+++ b/doc/cmp-tmux.txt
@@ -55,7 +55,8 @@ To configure this extension, add an options table (defaults shown):
             all_panes = false,
             label = '[tmux]',
             trigger_characters = { '.' },
-            trigger_characters_ft = {} -- { filetype = { '.' } }
+            trigger_characters_ft = {}, -- { filetype = { '.' } },
+            capture_history = false,
           }
         }
       }

--- a/lua/cmp_tmux/source.lua
+++ b/lua/cmp_tmux/source.lua
@@ -16,7 +16,7 @@ local default_config = {
     trigger_characters = { '.' },
     trigger_characters_ft = {},
     keyword_pattern = [[\w\+]],
-    history_limit = '0',
+    capture_history = false,
 }
 
 local function create_config()
@@ -41,10 +41,6 @@ end
 
 function source:get_keyword_pattern()
     return self.config.keyword_pattern
-end
-
-function source:get_history_limit()
-    return self.config.history_limit
 end
 
 function source:get_trigger_characters()

--- a/lua/cmp_tmux/source.lua
+++ b/lua/cmp_tmux/source.lua
@@ -16,6 +16,7 @@ local default_config = {
     trigger_characters = { '.' },
     trigger_characters_ft = {},
     keyword_pattern = [[\w\+]],
+    history_limit = '0',
 }
 
 local function create_config()
@@ -40,6 +41,10 @@ end
 
 function source:get_keyword_pattern()
     return self.config.keyword_pattern
+end
+
+function source:get_history_limit()
+    return self.config.history_limit
 end
 
 function source:get_trigger_characters()

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -51,7 +51,7 @@ end
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
     local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
     if self.config.capture_history then
-        cmd = table.insert(cmd, ' -S -')
+        table.insert(cmd, ' -S -')
     end
 
     return vim.fn.jobstart(cmd, {

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -51,7 +51,7 @@ end
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
     local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
     if self.config.capture_history then
-        table.insert(cmd, '-S -')
+        table.insert(cmd, '-S-')
     end
 
     return vim.fn.jobstart(cmd, {

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -49,7 +49,7 @@ function Tmux.get_panes(self, current_pane)
 end
 
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
-    local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane, '-S', self.config.history_limit }
+    local cmd = { 'tmux', 'capture-pane', '-p', '-S', self.config.history_limit, '-t', pane }
 
     return vim.fn.jobstart(cmd, {
         on_exit = on_exit,

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -51,7 +51,7 @@ end
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
     local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
     if self.config.capture_history then
-        cmd:append('-S -')
+        cmd = vim.tbl_extend('force', cmd, {'-S', '-'})
     end
 
     return vim.fn.jobstart(cmd, {

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -51,7 +51,7 @@ end
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
     local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
     if self.config.capture_history then
-        table.insert(cmd, ' -S -')
+        table.insert(cmd, '-S -')
     end
 
     return vim.fn.jobstart(cmd, {

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -49,7 +49,7 @@ function Tmux.get_panes(self, current_pane)
 end
 
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
-    local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
+    local cmd = { 'tmux', 'capture-pane', '-p', '-S-', '-t', pane }
 
     return vim.fn.jobstart(cmd, {
         on_exit = on_exit,

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -49,7 +49,7 @@ function Tmux.get_panes(self, current_pane)
 end
 
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
-    local cmd = { 'tmux', 'capture-pane', '-p', '-S' .. self.config.history_limit, '-t', pane }
+    local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane, '-S', self.config.history_limit }
 
     return vim.fn.jobstart(cmd, {
         on_exit = on_exit,

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -49,7 +49,7 @@ function Tmux.get_panes(self, current_pane)
 end
 
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
-    local cmd = { 'tmux', 'capture-pane', '-p', '-S-', '-t', pane }
+    local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane, '-S', self.config.history_limit }
 
     return vim.fn.jobstart(cmd, {
         on_exit = on_exit,

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -49,7 +49,7 @@ function Tmux.get_panes(self, current_pane)
 end
 
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
-    local cmd = { 'tmux', 'capture-pane', '-p', '-S', self.config.history_limit, '-t', pane }
+    local cmd = { 'tmux', 'capture-pane', '-p', '-S' .. self.config.history_limit, '-t', pane }
 
     return vim.fn.jobstart(cmd, {
         on_exit = on_exit,

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -51,7 +51,7 @@ end
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
     local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
     if self.config.capture_history then
-        cmd = vim.tbl_extend('force', cmd, {'-S', '-'})
+        cmd = vim.insert(cmd, '-S -')
     end
 
     return vim.fn.jobstart(cmd, {

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -49,7 +49,10 @@ function Tmux.get_panes(self, current_pane)
 end
 
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
-    local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane, '-S', self.config.history_limit }
+    local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
+    if self.config.capture_history then
+        cmd:append('-S -')
+    end
 
     return vim.fn.jobstart(cmd, {
         on_exit = on_exit,

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -51,7 +51,7 @@ end
 function Tmux.create_pane_data_job(self, pane, on_data, on_exit)
     local cmd = { 'tmux', 'capture-pane', '-p', '-t', pane }
     if self.config.capture_history then
-        cmd = vim.insert(cmd, '-S -')
+        cmd = table.insert(cmd, ' -S -')
     end
 
     return vim.fn.jobstart(cmd, {


### PR DESCRIPTION
By default, `tmux capture-pane` only captures what is visible on the pane. This means that any output that has scrolled off the pane is no longer being suggested by `cmp-tmux`. For example, on a MBP Pro 13" with terminal font of Menlo and font size of 11, with 2 vertical panes in tmux, the maximum number of visible lines is `~32 ±2`.

My use-case: `aws iam list-policies | jq -rc .Policies[]` produces more than `4,000` lines of output. I would like to be able to start typing an IAM Policy Name or IAM Policy ARN and have `cmp` fuzzily suggest completions from the entire pane history (via `tmux capture-pane -S-`).

I have tested this change on my tmux `history-limit` of `20000` and there were no noticeable performance issues.

### Screenshot

<img width="832" alt="Screenshot 2023-08-31 at 12 18 13 AM" src="https://github.com/andersevenrud/cmp-tmux/assets/6811830/45e46202-fd7c-4497-b203-10cf53375c59">

- Pane 1 (top): neovim with `cmp` + `cmp-tmux` suggestions
- Pane 2 (bottom): output from `cat /dev/random` exceeding 20,000 lines