### PR TITLE
Source from session panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tmux completion source for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 > This extension [pulls text from your current tmux session](https://github.com/andersevenrud/cmp-tmux/issues/14#issuecomment-924877836)
 > and provides it as a completion source.
 >
-> *By default this extension uses adjacent panes as sources. See [configuration](#configuration) to enable all panes.*
+> *By default this extension uses adjacent panes as sources. See [configuration](#configuration) to enable all session panes, or all panes across all sessions.*
 
 ## Requirements
 
@@ -45,8 +45,8 @@ require('cmp').setup({
     {
       name = 'tmux',
       option = {
-        -- Source from all panes in session instead of adjacent panes
-        all_panes = false,
+        -- Source from adjacent panes, all session panes or all panes across all sessions
+        scope = 'window', -- session, all
 
         -- Completion popup label
         label = '[tmux]',

--- a/doc/cmp-tmux.txt
+++ b/doc/cmp-tmux.txt
@@ -52,7 +52,7 @@ To configure this extension, add an options table (defaults shown):
         {
           name = 'tmux',
           option = {
-            all_panes = false,
+            scope = 'window',
             label = '[tmux]',
             trigger_characters = { '.' },
             trigger_characters_ft = {}, -- { filetype = { '.' } },

--- a/lua/cmp_tmux/source.lua
+++ b/lua/cmp_tmux/source.lua
@@ -10,7 +10,7 @@ local Tmux = require('cmp_tmux.tmux')
 local source = {}
 
 local default_config = {
-    all_panes = false,
+    scope = 'window',
     label = '[tmux]',
     trigger_characters = { '.' },
     trigger_characters_ft = {},

--- a/lua/cmp_tmux/tmux.lua
+++ b/lua/cmp_tmux/tmux.lua
@@ -27,7 +27,9 @@ function Tmux.get_panes(self, current_pane)
     local result = {}
 
     local cmd = "tmux list-panes -F '#{pane_id}'"
-    if self.config.all_panes then
+    if self.config.scope == 'session' then
+        cmd = cmd .. ' -s'
+    elseif self.config.scope == 'all' then
         cmd = cmd .. ' -a'
     end
 


### PR DESCRIPTION
At the moment tmux source is scoped to current window panes or all panes across all sessions. I personally find neither of those as useful as "all panes within current session". This pr adds this option.